### PR TITLE
Refactor victory and lose message functions to simplify parameters

### DIFF
--- a/src/scenes/basics/Scene.js
+++ b/src/scenes/basics/Scene.js
@@ -250,7 +250,7 @@ export default class Scene extends Phaser.Scene {
     try {
       import("../../utils/WebViewMessenger.js").then(({ sendLoseMessage }) => {
         if (typeof sendLoseMessage === "function") {
-          sendLoseMessage({ mapKey: this.mapKey, reason });
+          sendLoseMessage();
         }
       });
     } catch (e) {

--- a/src/utils/ProgramExecutor.js
+++ b/src/utils/ProgramExecutor.js
@@ -453,11 +453,7 @@ export class ProgramExecutor {
         import("./WebViewMessenger.js")
           .then(({ sendVictoryMessage }) => {
             if (typeof sendVictoryMessage === "function") {
-              sendVictoryMessage({
-                mapKey: this.scene.mapKey,
-                collected: victoryResult.collected,
-                required: victoryResult.required,
-              });
+              sendVictoryMessage();
             }
           })
           .catch((e) => console.warn("Cannot send victory message:", e));

--- a/src/utils/VictoryConditions.js
+++ b/src/utils/VictoryConditions.js
@@ -253,7 +253,7 @@ export function checkAndDisplayVictory(scene) {
     console.log(`   ${result.details.green}`);
   }
 
-  // Gửi kết quả đến webview bên ngoài
+  // Gửi kết quả đến webview bên ngoài (chỉ thắng/thua)
   sendBatteryCollectionResult(scene, result);
 
   return result;

--- a/src/utils/WebViewMessenger.js
+++ b/src/utils/WebViewMessenger.js
@@ -49,8 +49,8 @@ export function sendMessageToParent(type, data = {}) {
  * Gửi thông báo thắng đến trang web chứa iframe
  * @param {Object} victoryData - Dữ liệu về kết quả thắng
  */
-export function sendVictoryMessage(victoryData) {
-  return sendMessageToParent("VICTORY", victoryData);
+export function sendVictoryMessage() {
+  return sendMessageToParent("VICTORY", { isVictory: true });
 }
 
 /**
@@ -65,8 +65,8 @@ export function sendProgressMessage(progressData) {
  * Gửi thông báo thua đến trang web chứa iframe
  * @param {Object} loseData - Dữ liệu về thua cuộc
  */
-export function sendLoseMessage(loseData) {
-  return sendMessageToParent("LOSE", loseData);
+export function sendLoseMessage() {
+  return sendMessageToParent("LOSE", { isVictory: false });
 }
 
 /**
@@ -119,24 +119,11 @@ export function sendReadyMessage() {
  * @param {Object} victoryResult - Kết quả kiểm tra thắng thua
  */
 export function sendBatteryCollectionResult(scene, victoryResult) {
-  const messageType = victoryResult.isVictory ? "VICTORY" : "PROGRESS";
+  const messageType = victoryResult.isVictory ? "VICTORY" : "LOSE";
 
-  const messageData = {
-    mapKey: scene.mapKey,
+  return sendMessageToParent(messageType, {
     isVictory: victoryResult.isVictory,
-    progress: victoryResult.progress,
-    message: victoryResult.message,
-    collected: {
-      total: victoryResult.collected.total,
-      byType: victoryResult.collected.byType,
-    },
-    required: {
-      total: victoryResult.required.total,
-      byType: victoryResult.required.byType,
-    },
-  };
-
-  return sendMessageToParent(messageType, messageData);
+  });
 }
 
 /**


### PR DESCRIPTION
Updated sendVictoryMessage and sendLoseMessage functions to remove unnecessary parameters, now sending a default object indicating victory status. Adjusted related calls in Scene.js and ProgramExecutor.js to reflect these changes. Updated comments in VictoryConditions.js for clarity.