### PR TITLE
Add replay button and loading screen functionality

### DIFF
--- a/public/webview-harness.html
+++ b/public/webview-harness.html
@@ -22,6 +22,7 @@
         <button id="btnStart">START (LOAD_MAP_AND_CHALLENGE)</button>
         <button id="btnRun">RUN_PROGRAM</button>
         <button id="btnStatus">GET_STATUS</button>
+        <button id="btnReplay">REPLAY</button>
         <button id="btnClear">Clear Log</button>
       </div>
     </header>
@@ -107,6 +108,11 @@
 
       document.getElementById('btnStatus').onclick = () => {
         sendToGame('GET_STATUS');
+      };
+
+      // Replay: ask the game to restart/reload the scene
+      document.getElementById('btnReplay').onclick = () => {
+        sendToGame('RESTART_SCENE');
       };
 
       // Optional: Mock a Flutter-like channel for quick testing (shown in console)

--- a/src/main.js
+++ b/src/main.js
@@ -94,8 +94,8 @@ const config = {
   height: sizes.height,
   parent: "app",
   scale: {
-    mode: Phaser.Scale.FIT,
-    autoCenter: Phaser.Scale.CENTER_HORIZONTALLY,
+    mode: Phaser.Scale.HEIGHT_CONTROLS_WIDTH,
+    autoCenter: Phaser.Scale.CENTER_BOTH,
   },
   physics: {
     default: "arcade",

--- a/src/utils/WebViewMessenger.js
+++ b/src/utils/WebViewMessenger.js
@@ -390,6 +390,23 @@ export function initWebViewCommunication(game) {
           sendMessageToParent("STATUS", status);
         }
         break;
+
+      case "RESTART_SCENE":
+        // Khởi động lại scene hiện tại với dữ liệu đang có
+        {
+          const current = game.scene.getScene("Scene");
+          if (current) {
+            const payload = {
+              mapJson: current.mapJson || null,
+              challengeJson: current.challengeJson || null,
+            };
+            current.scene.restart(payload);
+          } else {
+            // Nếu scene chưa chạy, chỉ cần start (sẽ hiện loading UI nếu thiếu data)
+            game.scene.start("Scene", {});
+          }
+        }
+        break;
     }
   });
 
@@ -420,6 +437,19 @@ export function initWebViewCommunication(game) {
         };
       }
       return null;
+    },
+
+    restart: () => {
+      const scene = game.scene.getScene("Scene");
+      if (scene) {
+        scene.scene.restart({
+          mapJson: scene.mapJson || null,
+          challengeJson: scene.challengeJson || null,
+        });
+        return true;
+      }
+      game.scene.start("Scene", {});
+      return true;
     },
   };
 }


### PR DESCRIPTION
- Introduced a new "REPLAY" button in the webview harness to allow users to restart the game scene.
- Implemented a loading screen in the Scene class to provide feedback while waiting for map and challenge data from the webview.
- Enhanced error handling by replacing the error message display with a loading screen when data is not available.
- Updated the WebViewMessenger to handle scene restart requests, improving the game's responsiveness to user actions.