### PR TITLE
Refactor action handling and remove unused banner methods

### DIFF
--- a/public/webview-harness.html
+++ b/public/webview-harness.html
@@ -147,9 +147,9 @@
           programName: "demo_headless",
           actions: [
             { type: "forward", count: 2 },
-            { type: "collect", color: "yellow", count: 3 },
+            { type: "collect", color: "yellow", count: 2 },
             { type: "forward", count: 2 },
-            { type: "collect", color: "yellow", count: 3 },
+            { type: "collect", color: "yellow", count: 2 },
           ],
         };
         sendToGame("RUN_PROGRAM_HEADLESS", { program });
@@ -165,7 +165,7 @@
           { type: "forward", count: 2 },
           { type: "collect", color: "yellow", count: 2 },
           { type: "forward", count: 2 },
-          { type: "collect", color: "yellow", count: 3 },
+          { type: "collect", color: "yellow", count: 2 },
         ];
         sendToGame("EXECUTE_PHYSICAL_ROBOT_ACTIONS", { actions });
       };

--- a/src/managers/GameUIManager.js
+++ b/src/managers/GameUIManager.js
@@ -66,30 +66,7 @@ export class GameUIManager {
     });
   }
 
-  /**
-   * Hiển thị banner chiến thắng ngắn gọn
-   * @param {string} message - Message to display
-   * @param {string} background - Background color (default: "#006600")
-   */
-  showBanner(message, background = "#006600") {
-    const x = this.scene.cameras.main.width / 2;
-    const y = this.scene.cameras.main.height / 2 - 120;
-    const text = this.scene.add.text(x, y, message, {
-      fontFamily: "Arial",
-      fontSize: "22px",
-      color: "#ffffff",
-      backgroundColor: background,
-      padding: { x: 16, y: 10 },
-    });
-    text.setOrigin(0.5, 0.5);
-    this.scene.tweens.add({
-      targets: text,
-      alpha: { from: 1, to: 0 },
-      duration: 1500,
-      delay: 800,
-      onComplete: () => text.destroy(),
-    });
-  }
+  // (Removed) showBanner: generic center-screen banner not needed for win/lose
 
   /**
    * Hiển thị yêu cầu chiến thắng của map hiện tại
@@ -346,22 +323,9 @@ export class GameUIManager {
     }
   }
 
-  /**
-   * Hiển thị thông báo thua cuộc
-   * @param {string} reason - Lý do thua cuộc
-   */
-  showLoseMessage(reason) {
-    console.warn(`💥 THUA CUỘC: ${reason}`);
-    this.showBanner(reason, "#8B0000");
-  }
+  // (Removed) showLoseMessage: FE/MB display lose reason externally
 
-  /**
-   * Hiển thị thông báo chiến thắng
-   * @param {string} message - Thông báo chiến thắng
-   */
-  showVictoryMessage(message) {
-    this.showBanner(message, "#006600");
-  }
+  // (Removed) showVictoryMessage: FE/MB display win reason externally
 
   /**
    * Hiển thị thông báo tiến độ

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -525,19 +525,14 @@ export default class Scene extends Phaser.Scene {
     this.uiManager.showToast(message, background);
   }
 
-  /**
-   * Hiển thị banner chiến thắng ngắn gọn
-   */
-  showBanner(message, background = "#006600") {
-    this.uiManager.showBanner(message, background);
-  }
+  // (Removed) showBanner: No longer used; FE/MB handle messages via webview
 
   /**
    * Thua cuộc với lý do cụ thể
    */
   lose(reason) {
     this.gameState = "lost";
-    this.uiManager.showLoseMessage(reason);
+    // Skip showing in-Phaser lose banner; handled by FE/MB via webview message
     // Gửi thông báo thua ra webview
     try {
       import("../utils/WebViewMessenger.js").then(({ sendLoseMessage }) => {
@@ -563,7 +558,7 @@ export default class Scene extends Phaser.Scene {
    */
   win(reason) {
     this.gameState = "won";
-    this.uiManager.showBanner(reason || "Chiến thắng!", "#006600");
+    // Skip showing in-Phaser win banner; handled by FE/MB via webview message
     // Gửi thông báo thắng ra webview
     try {
       import("../utils/WebViewMessenger.js").then(({ sendVictoryMessage }) => {
@@ -839,7 +834,7 @@ export default class Scene extends Phaser.Scene {
       actions: [
         {
           type: "repeat",
-          count: 4,
+          count: 2,
           body: [
             {
               type: "forward",
@@ -848,7 +843,7 @@ export default class Scene extends Phaser.Scene {
             {
               type: "collect",
               count: 2,
-              color: "yellow",
+              color: "red",
             },
           ],
         },


### PR DESCRIPTION
- Adjusted action counts for collecting yellow items in webview harness.
- Removed showBanner, showLoseMessage, and showVictoryMessage methods from GameUIManager, as they are no longer needed for win/lose notifications.
- Updated Scene class to skip in-Phaser banners for win/lose, now handled via webview messaging.
- Modified action count for repeat actions in Scene to improve gameplay consistency.